### PR TITLE
Validate URLs in OpenUrlTrigger

### DIFF
--- a/Triggers/OpenUrlTrigger.cs
+++ b/Triggers/OpenUrlTrigger.cs
@@ -26,7 +26,7 @@ public sealed class OpenUrlTrigger : Trigger
         Uri validURL;
         if (Uri.TryCreate(url, UriKind.Absolute, out Uri validURL))
         {
-            safe = (validURL.Scheme == Uri.UriSchemeHttp || validURL.Scheme = Uri.UriSchemeHttps);
+            safe = (validURL.Scheme == Uri.UriSchemeHttp || validURL.Scheme == Uri.UriSchemeHttps);
         }
         else safe = false;
     }

--- a/Triggers/OpenUrlTrigger.cs
+++ b/Triggers/OpenUrlTrigger.cs
@@ -2,6 +2,7 @@
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using System;
+using System.Uri;
 
 namespace ChroniaHelper.Triggers;
 
@@ -12,26 +13,41 @@ public sealed class OpenUrlTrigger : Trigger
     private readonly string url;
     private readonly bool once;
     private readonly bool loadOnce;
-
+    private bool safe;
+    
     public OpenUrlTrigger(EntityData data, Vector2 offset, EntityID id) : base(data, offset)
     {
         this.id = id;
-        url = data.Attr("url", "https://www.celestegame.com/");
         once = data.Bool("once", false);
         loadOnce = data.Bool("loadOnce", false);
+        url = data.Attr("url", "https://www.celestegame.com/");
+
+        // Ensure a URL is being opened and not arbitrary code
+        Uri validURL;
+        if (Uri.TryCreate(url, UriKind.Absolute, out Uri validURL))
+        {
+            safe = (validURL.Scheme == Uri.UriSchemeHttp || validURL.Scheme = Uri.UriSchemeHttps);
+        }
+        else safe = false;
     }
 
     public override void OnEnter(Player player)
     {
         base.OnEnter(player);
-        try
-        {
-            ProcessStartInfo info = new(url) { UseShellExecute = true };
-            Process.Start(info);
+        if (safe) { 
+            try
+            {
+                ProcessStartInfo info = new(url) { UseShellExecute = true };
+                Process.Start(info);
+            }
+            catch (Exception e)
+            {
+                Logger.LogDetailed(e, "OpenUrlHelper");
+            }
         }
-        catch (Exception e)
+        else
         {
-            Logger.LogDetailed(e, "OpenUrlHelper");
+            Logger.LogError("OpenUrlHelper", "Invalid URL! It should match the https://www.whatever.com format.");
         }
         if (once)
             RemoveSelf();

--- a/Triggers/OpenUrlTrigger.cs
+++ b/Triggers/OpenUrlTrigger.cs
@@ -47,7 +47,7 @@ public sealed class OpenUrlTrigger : Trigger
         }
         else
         {
-            Logger.LogError("OpenUrlHelper", "Invalid URL! It should match the https://www.whatever.com format.");
+            Logger.LogError("OpenUrlHelper", "Invalid URL! It should match the \"https://www.example.com\" format.");
         }
         if (once)
             RemoveSelf();


### PR DESCRIPTION
The way OpenUrlTrigger is currently implemented allows for completely arbitrary code execution (see video):
https://github.com/user-attachments/assets/0bf6e148-8f1a-48c4-aaf3-fbc0a05d8698
Using the Uri validation built into .NET, this should ensure the url being passed in is actually a URL and thus reduce the malware risk. Tested, but would appreciate testing of non-standard (e.g. non-English) URLs that I might not have thought of

